### PR TITLE
Add Streaming Support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+# http://flake8.pycqa.org/en/latest/user/configuration.html#project-configuration
+# https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
+# TODO: https://github.com/PyCQA/flake8/issues/234
+doctests = True
+ignore = DAR103,E203,E501,FS003,S101,W503,S113
+max_line_length = 100
+max_complexity = 10
+
+# https://github.com/terrencepreilly/darglint#flake8
+# TODO: https://github.com/terrencepreilly/darglint/issues/130
+docstring_style = numpy
+strictness = long

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,83 @@
+# https://pre-commit.com
+default_install_hook_types: [commit-msg, pre-commit]
+default_stages: [commit, manual]
+fail_fast: true
+repos:
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: python-check-blanket-type-ignore
+      - id: python-check-mock-methods
+      - id: python-no-eval
+      - id: python-no-log-warn
+      - id: python-use-type-annotations
+      - id: python-check-blanket-noqa
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-vcs-permalinks
+      - id: check-xml
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+        types: [python]
+      - id: end-of-file-fixer
+        types: [python]
+  - repo: local
+    hooks:
+      - id: pycln
+        name: pycln
+        entry: pycln --all
+        language: python
+        types: [python]
+      - id: isort
+        name: isort
+        entry: isort
+        require_serial: true
+        language: python
+        types: [python]
+        args: [ "--profile", "black" ]
+      - id: black
+        name: black
+        entry: black
+        require_serial: true
+        language: python
+        types: [python]
+#      - id: shellcheck
+#        name: shellcheck
+#        entry: shellcheck --check-sourced
+#        language: system
+#        types: [shell]
+      - id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        types: [python]
+#      - id: pydocstyle
+#        name: pydocstyle
+#        entry: pydocstyle
+#        language: system
+#        types: [python]
+#      - id: mypy
+#        name: mypy
+#        entry: mypy
+#        language: system
+#        types: [python]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-steamship==2.15.0
 requests
+git+https://github.com/steamship-core/python-client.git@refs/pull/548/head

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-git+https://github.com/steamship-core/python-client.git@refs/pull/548/head
+git+https://github.com/steamship-core/python-client.git

--- a/src/api.py
+++ b/src/api.py
@@ -216,6 +216,7 @@ class ElevenlabsPlugin(StreamingGenerator):
         ]
         return InvocableResponse(
             data=StreamCompletePluginOutput(
+                usage=usage
             ),
         )
 

--- a/src/api.py
+++ b/src/api.py
@@ -2,7 +2,7 @@
 import logging
 import time
 import uuid
-from typing import Type
+from typing import Iterator, Type
 
 import requests
 from pydantic import Field
@@ -117,7 +117,7 @@ def create_usage_report(input_text: str, for_url: str) -> UsageReport:
 
 def generate_audio_stream(
     input_text: str, audit_url: str, config: ElevenlabsPluginConfig
-) -> (bytes, UsageReport):
+) -> (Iterator[bytes], UsageReport):
     data = {
         "text": input_text,
         "model_id": config.model_id,

--- a/src/api.py
+++ b/src/api.py
@@ -149,7 +149,6 @@ def generate_audio_stream(input_text: str, audit_url: str, config: ElevenlabsPlu
         raise SteamshipError(f"Received status code {response.status_code} from Eleven Labs. Reason: {response.reason}")
 
 
-
 class ElevenlabsPlugin(StreamingGenerator):
     """Eleven Labs Text-to-Speech generator."""
 
@@ -184,12 +183,12 @@ class ElevenlabsPlugin(StreamingGenerator):
         if not request.data.output_blocks:
             raise SteamshipError(message="Empty output blocks structure was provided. Need at least one to stream into.")
 
-        if not len(request.data.output_blocks) > 1:
+        if len(request.data.output_blocks) > 1:
             raise SteamshipError(message="More than one output block provided. This plugin assumes only one output block.")
 
         # Prepare data
 
-        output_block = request.data.output_blocks[i]
+        output_block = request.data.output_blocks[0]
         prompt_text = " ".join([block.text for block in request.data.blocks if block.text is not None])
         audit_url = f"https://api.steamship.com/api/v1/block/{output_block.id}/raw"
 

--- a/src/api.py
+++ b/src/api.py
@@ -216,7 +216,7 @@ class ElevenlabsPlugin(StreamingGenerator):
         ]
         return InvocableResponse(
             data=StreamCompletePluginOutput(
-                usage=usage
+                usage=usages
             ),
         )
 

--- a/src/api.py
+++ b/src/api.py
@@ -18,6 +18,14 @@ from steamship.plugin.outputs.plugin_output import UsageReport, OperationType, O
 from steamship.plugin.outputs.raw_block_and_tag_plugin_output import RawBlockAndTagPluginOutput
 from steamship.plugin.request import PluginRequest
 from steamship.utils.signed_urls import upload_to_signed_url
+from steamship.plugin.outputs.block_type_plugin_output import BlockTypePluginOutput
+from steamship.plugin.inputs.raw_block_and_tag_plugin_input_with_preallocated_blocks import (
+    RawBlockAndTagPluginInputWithPreallocatedBlocks,
+)
+
+from steamship.plugin.outputs.stream_complete_plugin_output import StreamCompletePluginOutput
+from steamship.plugin.request import PluginRequest
+from steamship.plugin.streaming_generator import StreamingGenerator
 
 import uuid
 
@@ -100,6 +108,7 @@ class ElevenlabsPluginConfig(Config):
     )
     stability: float = Field(0.5, description="")
     similarity_boost: float = Field(0.8, description="")
+    optimize_streaming_latency: int = Field(0, description="[Optional] An integer from [0,4]. How much to optimize for latency. 0 (Default) is no optimization with highest quality. 4 is lowest latency but may mispronounce words.")
 
 
 def create_usage_report(input_text: str, for_url: str) -> UsageReport:
@@ -111,35 +120,37 @@ def create_usage_report(input_text: str, for_url: str) -> UsageReport:
         audit_id=for_url
     )
 
-def generate_audio(input_text: str, audit_url: str, config: ElevenlabsPluginConfig) -> (bytes, UsageReport):
+
+def generate_audio_stream(input_text: str, audit_url: str, config: ElevenlabsPluginConfig) -> (bytes, UsageReport):
     data = {
         "text": input_text,
         "model_id": config.model_id,
         "voice_settings": {
             "stability": config.stability,
-            "similarity_boost": config.similarity_boost
+            "similarity_boost": config.similarity_boost,
         }
     }
 
     headers = {
         'xi-api-key': f"{config.elevenlabs_api_key}",
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'accept': 'audio/mpeg'
     }
 
-    url = f"https://api.elevenlabs.io/v1/text-to-speech/{config.voice_id}"
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{config.voice_id}/stream?optimize_streaming_latency={config.optimize_streaming_latency}"
     logging.debug(f"Making request to {url}")
 
-    response = requests.post(url, json=data, headers=headers)
+    response = requests.post(url, json=data, headers=headers, stream=True)
 
     if response.status_code == 200:
-        _bytes = response.content
         usage = create_usage_report(input_text, audit_url)
-        return _bytes, usage
+        return response.iter_content(), usage
     else:
         raise SteamshipError(f"Received status code {response.status_code} from Eleven Labs. Reason: {response.reason}")
 
 
-class ElevenlabsPlugin(Generator):
+
+class ElevenlabsPlugin(StreamingGenerator):
     """Eleven Labs Text-to-Speech generator."""
 
     config: ElevenlabsPluginConfig
@@ -149,9 +160,20 @@ class ElevenlabsPlugin(Generator):
         """Return configuration template for the generator."""
         return ElevenlabsPluginConfig
 
+    def determine_output_block_types(
+        self, request: PluginRequest[RawBlockAndTagPluginInput]
+    ) -> InvocableResponse[BlockTypePluginOutput]:
+        """For Streaming operation.
+        
+        We stream into a single block. A future version of this plugin may generate multiple streams in
+        parallel for multi-block input.
+        """
+        result = [MimeTypes.MP3.value]
+        return InvocableResponse(data=BlockTypePluginOutput(block_types_to_create=result))
+
     def run(
-            self, request: PluginRequest[RawBlockAndTagPluginInput]
-    ) -> InvocableResponse[RawBlockAndTagPluginOutput]:
+        self, request: PluginRequest[RawBlockAndTagPluginInputWithPreallocatedBlocks]
+    ) -> InvocableResponse[StreamCompletePluginOutput]:
 
         if not self.config.voice_id:
             raise SteamshipError(message=f"Must provide an Eleven Labs voice_id")
@@ -159,28 +181,42 @@ class ElevenlabsPlugin(Generator):
         if not self.context.invocable_instance_handle:
             raise SteamshipError(message="Empty invocable_instance_handle was provided; unable to save audio file.")
 
-        into_filename = f"{self.context.invocable_instance_handle}/{str(uuid.uuid4())}.mp3"
+        if not request.data.output_blocks:
+            raise SteamshipError(message="Empty output blocks structure was provided. Need at least one to stream into.")
 
+        if not len(request.data.output_blocks) > 1:
+            raise SteamshipError(message="More than one output block provided. This plugin assumes only one output block.")
+
+        # Prepare data
+
+        output_block = request.data.output_blocks[i]
         prompt_text = " ".join([block.text for block in request.data.blocks if block.text is not None])
+        audit_url = f"https://api.steamship.com/api/v1/block/{output_block.id}/raw"
+
+        # Begin Streaming
 
         start_time = time.time()
-        _bytes, usage = generate_audio(prompt_text, into_filename, self.config)
+        
+        _stream, usage = generate_audio_stream(prompt_text, audit_url, self.config)
+        for chunk in _stream:
+            output_block.append_stream(bytes=chunk)
+        output_block.finish_stream()
         end_time = time.time()
+
+        # Some light logging
+
         elapsed_time = end_time - start_time
-        logging.debug(f"Retrieved audio data in f{elapsed_time}")
+        logging.debug(f"Completed audio stream in f{elapsed_time}")
 
-        url = save_audio(self.client, self.context.invocable_instance_handle, _bytes)
-
-        blocks = [
-            Block(url=url, mime_type=MimeTypes.MP3, upload_type=BlockUploadType.URL)
-        ]
+        # Return a sync result
+        # TODO: How do we report
 
         usages = [
             usage
         ]
         return InvocableResponse(
-            data=RawBlockAndTagPluginOutput(
-                blocks=blocks,
-                usage=usages
+            data=StreamCompletePluginOutput(
             ),
         )
+
+

--- a/src/api.py
+++ b/src/api.py
@@ -20,6 +20,8 @@ from steamship.plugin.request import PluginRequest
 from steamship.plugin.streaming_generator import StreamingGenerator
 from steamship.utils.signed_urls import upload_to_signed_url
 
+# Example Voices
+
 
 def save_audio(client: Steamship, plugin_instance_id: str, audio: bytes) -> str:
     """Saves audio bytes to the user's workspace."""
@@ -141,7 +143,7 @@ def generate_audio_stream(
         return response.iter_content(chunk_size=1000), usage
     else:
         raise SteamshipError(
-            f"Received status code {response.status_code} from Eleven Labs. Reason: {response.reason}"
+            f"Received status code {response.status_code} from Eleven Labs. Reason: {response.reason}. Message: {response.text}"
         )
 
 

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "elevenlabs-ted",
-	"version": "1.0.6-rc.7",
+	"version": "1.0.6-rc.8",
 	"description": "",
 	"author": "ted",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "elevenlabs-ted",
-	"version": "1.0.6-rc.1",
+	"version": "1.0.6-rc.2",
 	"description": "",
 	"author": "ted",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "elevenlabs-ted",
-	"version": "1.0.6-rc.5",
+	"version": "1.0.6-rc.7",
 	"description": "",
 	"author": "ted",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,6 +1,6 @@
 {
 	"type": "plugin",
-	"handle": "elevenlabs-ted",
+	"handle": "elevenlabs",
 	"version": "1.0.6-rc.8",
 	"description": "",
 	"author": "ted",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
-	"handle": "elevenlabs",
-	"version": "1.0.5",
+	"handle": "elevenlabs-ted",
+	"version": "1.0.6-rc.1",
 	"description": "",
 	"author": "ted",
 	"entrypoint": "Unused",
@@ -9,7 +9,8 @@
 	"plugin": {
 		"isTrainable": false,
 		"transport": "jsonOverHttp",
-		"type": "generator"
+		"type": "generator",
+		"streaming": true
 	},
 	"build_config": {
 		"ignore": [
@@ -28,6 +29,11 @@
 			"description": "Voice ID to use. Defaults to Rachel (21m00Tcm4TlvDq8ikWAM)",
 			"default": "21m00Tcm4TlvDq8ikWAM"
 		},
+		"model_id": {
+			"type": "string",
+			"description": "Model ID to use. Defaults to eleven_monolingual_v1. Also available: eleven_multilingual_v1",
+			"default": "eleven_monolingual_v1"
+		},
 		"stability": {
 			"type": "number",
 			"description": "",
@@ -37,6 +43,11 @@
 			"type": "number",
 			"description": "",
 			"default": 0.8
+		},
+		"optimize_streaming_latency": {
+			"type": "number",
+			"description": "[Optional] An integer from [0,4]. How much to optimize for latency. 0 (Default) is no optimization with highest quality. 4 is lowest latency but may mispronounce words.",
+			"default": 0
 		}
 	},
 	"steamshipRegistry": {

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "elevenlabs-ted",
-	"version": "1.0.6-rc.2",
+	"version": "1.0.6-rc.5",
 	"description": "",
 	"author": "ted",
 	"entrypoint": "Unused",

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -3,30 +3,27 @@
 from filetype import filetype
 from steamship import File, MimeTypes, Steamship
 
-GENERATOR_HANDLE = "elevenlabs"
+GENERATOR_HANDLE = "elevenlabs-ted"
 
 
-def test_generator():
+def test_streaming_audio():
     with Steamship.temporary_workspace() as client:
-        sd = client.use_plugin(IMAGE_GENERATOR_HANDLE)
+        generator = client.use_plugin(GENERATOR_HANDLE)
 
         test_file = File.create(client, handle="test-script", content="script")
-        task = sd.generate(
-            text="A cat on a bicycle",
+        task = generator.generate(
+            text="Hello there! This response was generated with streaming!",
             append_output_to_file=True,
             output_file_id=test_file.id,
-            options={"size": "512x512", "negative_prompt": "water bottles"},
         )
         task.wait()
 
-        test_file.append_block(text="give the cat a helmet")
-        pix2pix = client.use_plugin(MULTI_MODAL_GENERATOR_HANDLE)
-        pix_task = pix2pix.generate(input_file_id=test_file.id)
-        pix_task.wait(max_timeout_s=600)
+        test_file = test_file.refresh()
 
-        block = pix_task.output.blocks[0]
+        block = test_file.blocks[0]
 
         assert block is not None
-        # check that Steamship thinks it is a PNG and that the bytes seem like a PNG
-        assert block.mime_type == MimeTypes.JPG
-        assert filetype.guess_mime(block.raw()) == MimeTypes.JPG
+        assert block.mime_type == MimeTypes.MP3
+
+        with open("foo.mp3", "wb") as f:
+            f.write(block.raw())

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,70 +1,37 @@
 """Test dall-e generator plugin via integration tests."""
 
-from filetype import filetype
-from steamship import File, MimeTypes, Steamship, Block
 from time import sleep
+
+from steamship import File, Steamship
 
 GENERATOR_HANDLE = "elevenlabs-ted"
 
 
-def test_streaming_audio():
-    with Steamship.temporary_workspace() as client:
-        generator = client.use_plugin(GENERATOR_HANDLE)
-
-        test_file = File.create(client, handle="test-script", content="script")
-        task = generator.generate(
-            text="Hello there! This response was generated with streaming!",
-            append_output_to_file=True,
-            output_file_id=test_file.id,
-            make_output_public=True
-        )
-
-        task.wait()
-
-        test_file = test_file.refresh()
-        block = test_file.blocks[0]
-
-        assert block is not None
-        assert block.mime_type == MimeTypes.MP3
-        assert block.public_data
-
-
 def test_streaming_audio_long():
-    client = Steamship(profile="staging", workspace="eleven-airplane-2")
+    client = Steamship(profile="staging", workspace="eleven-airplane-4")
     generator = client.use_plugin(GENERATOR_HANDLE)
     generator.wait_for_init()
 
-    rows = []
-    for i in range(2):
-        rows.append(f"This is sentence {i}.")
-    text = "\n".join(rows)
-
     test_file = File.create(client)
-
-    # b = Block.create(client, file_id=test_file.id, text="HI", public_data=True)
-    # r = b.raw()
 
     task = generator.generate(
         text="Hello there! This response was generated with streaming!",
         append_output_to_file=True,
         output_file_id=test_file.id,
-        make_output_public=True
+        make_output_public=True,
     )
+    assert task.task_id
+
     sleep(2)
 
     test_file = test_file.refresh()
 
     block = test_file.blocks[0]
-    
+
     # It's public
     assert block is not None
     assert block.public_data
 
-    with open('out.mpt', 'wb') as f2:
-        f2.write(block.raw())
-
-    url = f"https://api.staging.steamship.com/block/{block.id}/raw"
+    url = f"https://api.staging.steamship.com/api/v1/block/{block.id}/raw"
 
     print(url)
-
-

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,7 +1,7 @@
 """Test dall-e generator plugin via integration tests."""
 
 from filetype import filetype
-from steamship import File, MimeTypes, Steamship
+from steamship import File, MimeTypes, Steamship, Block
 from time import sleep
 
 GENERATOR_HANDLE = "elevenlabs-ted"
@@ -30,15 +30,20 @@ def test_streaming_audio():
 
 
 def test_streaming_audio_long():
-    client = Steamship(profile="test")
+    client = Steamship(profile="staging", workspace="eleven-airplane-2")
     generator = client.use_plugin(GENERATOR_HANDLE)
+    generator.wait_for_init()
 
     rows = []
-    for i in range(100):
+    for i in range(2):
         rows.append(f"This is sentence {i}.")
     text = "\n".join(rows)
 
     test_file = File.create(client)
+
+    # b = Block.create(client, file_id=test_file.id, text="HI", public_data=True)
+    # r = b.raw()
+
     task = generator.generate(
         text="Hello there! This response was generated with streaming!",
         append_output_to_file=True,
@@ -54,6 +59,9 @@ def test_streaming_audio_long():
     # It's public
     assert block is not None
     assert block.public_data
+
+    with open('out.mpt', 'wb') as f2:
+        f2.write(block.raw())
 
     url = f"https://api.staging.steamship.com/block/{block.id}/raw"
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -2,6 +2,7 @@
 
 from filetype import filetype
 from steamship import File, MimeTypes, Steamship
+from time import sleep
 
 GENERATOR_HANDLE = "elevenlabs-ted"
 
@@ -15,15 +16,47 @@ def test_streaming_audio():
             text="Hello there! This response was generated with streaming!",
             append_output_to_file=True,
             output_file_id=test_file.id,
+            make_output_public=True
         )
+
         task.wait()
 
         test_file = test_file.refresh()
-
         block = test_file.blocks[0]
 
         assert block is not None
         assert block.mime_type == MimeTypes.MP3
+        assert block.public_data
 
-        with open("foo.mp3", "wb") as f:
-            f.write(block.raw())
+
+def test_streaming_audio_long():
+    client = Steamship(profile="test")
+    generator = client.use_plugin(GENERATOR_HANDLE)
+
+    rows = []
+    for i in range(100):
+        rows.append(f"This is sentence {i}.")
+    text = "\n".join(rows)
+
+    test_file = File.create(client)
+    task = generator.generate(
+        text="Hello there! This response was generated with streaming!",
+        append_output_to_file=True,
+        output_file_id=test_file.id,
+        make_output_public=True
+    )
+    sleep(2)
+
+    test_file = test_file.refresh()
+
+    block = test_file.blocks[0]
+    
+    # It's public
+    assert block is not None
+    assert block.public_data
+
+    url = f"https://api.staging.steamship.com/block/{block.id}/raw"
+
+    print(url)
+
+

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -8,14 +8,27 @@ GENERATOR_HANDLE = "elevenlabs-ted"
 
 
 def test_streaming_audio_long():
-    client = Steamship(profile="staging", workspace="eleven-airplane-4")
+    """THIS TEST IS INTENDED TO BE PERFORMED MANUALLY.
+
+    It creates
+    """
+
+    # Set this to a high number if you want to test streaming while it's still generating.
+    # Then set a breakpoint to get the URL below.
+    BOTTLES_OF_BEER_ON_THE_WALL = 10
+
+    client = Steamship(profile="staging", workspace="eleven-home-1")
     generator = client.use_plugin(GENERATOR_HANDLE)
     generator.wait_for_init()
 
     test_file = File.create(client)
 
+    text = "Want to hear a song?"
+    for i in range(BOTTLES_OF_BEER_ON_THE_WALL, 0, -1):
+        text += f"\n{i} bottles of beer on the wall, {i} bottles of beer."
+
     task = generator.generate(
-        text="Hello there! This response was generated with streaming!",
+        text=text,
         append_output_to_file=True,
         output_file_id=test_file.id,
         make_output_public=True,

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -1,6 +1,8 @@
 """Test dall-e generator plugin via integration tests."""
-
-from steamship import Block, File, MimeTypes, Steamship
+import pytest
+import requests
+from pydantic import BaseModel
+from steamship import Block, File, MimeTypes, Steamship, SteamshipError
 from steamship.invocable import InvocationContext
 from steamship.plugin.inputs.raw_block_and_tag_plugin_input_with_preallocated_blocks import (
     RawBlockAndTagPluginInputWithPreallocatedBlocks,
@@ -31,7 +33,7 @@ def test_stream_into_block():
         assert raw_value is not None
 
 
-def test_stream_into_block_with_hindi():
+def test_stream_into_block_with_hindi_and_multilingual_v1():
     """Tests Hindi support."""
     with Steamship.temporary_workspace() as client:
         plugin = ElevenlabsPlugin(
@@ -41,6 +43,31 @@ def test_stream_into_block_with_hindi():
         )
 
         text = "साइकिल पर एक बिल्ली"
+        f = File.create(client)
+        output_block = Block.create(
+            client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3
+        )
+        usage = plugin.stream_into_block(text, output_block)
+
+        assert usage.operation_unit == OperationUnit.CHARACTERS
+        assert usage.operation_type == OperationType.RUN
+        assert usage.operation_amount == len(text)
+        assert usage.audit_id == f"{client.config.api_base}block/{output_block.id}/raw"
+
+        raw_value = output_block.raw()
+        assert raw_value is not None
+
+
+def test_stream_into_block_with_chinese_and_multilingual_2():
+    """Tests Hindi support."""
+    with Steamship.temporary_workspace() as client:
+        plugin = ElevenlabsPlugin(
+            client,
+            {"model_id": "eleven_multilingual_v2"},
+            InvocationContext(invocable_instance_handle="foo"),
+        )
+
+        text = "你好。我是你的電腦。"
         f = File.create(client)
         output_block = Block.create(
             client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3
@@ -92,3 +119,57 @@ def test_generator_streaming():
         assert len(resp.data.usage) == 1
         assert resp.data.usage[0].operation_amount == len(text)
         assert resp.data.usage[0].operation_unit == OperationUnit.CHARACTERS
+
+
+VOICE_WE_TRAINED = "sAS41M2pfBJrC1X5MYgR"  # Rick
+VOICE_WE_ADDED = "IdZRgDjRZjFkdCn6m1Nl"  # Marcus
+VOICE_WITH_STOCK_SET = "pNInz6obpgDQGcFmaJgB"  # Adam
+VOICE_WE_DIDNT_ADD = "EgEq4qIbc5V6v0CUTckG"  #
+
+
+def test_get_voices():
+    """Tests top see which voices are returned to us by the /voices endpoint."""
+
+    class Voice(BaseModel):
+        voice_id: str
+        name: str
+
+    with Steamship.temporary_workspace() as client:
+        plugin = ElevenlabsPlugin(client, None, InvocationContext(invocable_instance_handle="foo"))
+
+        resp = requests.get(
+            "https://api.elevenlabs.io/v1/voices",
+            headers={"xi-api-key": plugin.config.elevenlabs_api_key},
+        )
+        j = resp.json()
+
+        voices = [Voice.parse_obj(voice_dict) for voice_dict in j.get("voices")]
+        voice_ids = [voice.voice_id for voice in voices]
+
+        for voice in voices:
+            print(f"- {voice}")
+        assert VOICE_WE_TRAINED in voice_ids
+        assert VOICE_WE_ADDED in voice_ids
+        assert VOICE_WITH_STOCK_SET in voice_ids
+        assert VOICE_WE_DIDNT_ADD not in voice_ids
+
+
+def test_generate_with_third_party_public_voice_we_didnt_add():
+    """Tests to verify that one has to first "add" a voice before using it via the API."""
+
+    with Steamship.temporary_workspace() as client:
+        plugin = ElevenlabsPlugin(
+            client,
+            {"voice_id": VOICE_WE_DIDNT_ADD},
+            InvocationContext(invocable_instance_handle="foo"),
+        )
+
+        text = "Hi there"
+        f = File.create(client)
+        output_block = Block.create(
+            client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3
+        )
+
+        # This won't work :( That's a bummer.
+        with pytest.raises(SteamshipError, match=r"voice_id.*does not exist"):
+            plugin.stream_into_block(text, output_block)

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -6,6 +6,7 @@ from steamship.plugin.inputs.raw_block_and_tag_plugin_input import RawBlockAndTa
 from steamship.plugin.outputs.plugin_output import OperationUnit
 from steamship.plugin.request import PluginRequest
 
+
 from api import ElevenlabsPlugin
 
 def test_generator():
@@ -66,3 +67,30 @@ def test_generator_hindi():
         assert resp.data.usage[0].operation_amount == len(text)
         assert resp.data.usage[0].operation_unit == OperationUnit.CHARACTERS
 
+def test_generator_streaming():
+    with Steamship.temporary_workspace() as client:
+        plugin = ElevenlabsPlugin(client, None, InvocationContext(
+            invocable_instance_handle="foo"
+        ))
+
+        text = "Hi there"
+        req = PluginRequest(data=RawBlockAndTagPluginInput(
+            blocks=[
+                Block(text=text)
+            ]
+        ))
+
+        resp = plugin.run(req)
+
+        assert resp.data.blocks is not None
+        block = resp.data.blocks[0]
+
+        assert block is not None
+
+        # check that Steamship thinks it is a PNG and that the bytes seem like a PNG
+        assert block.mime_type == MimeTypes.MP3
+        assert block.url is not None
+
+        assert len(resp.data.usage) == 1
+        assert resp.data.usage[0].operation_amount == len(text)
+        assert resp.data.usage[0].operation_unit == OperationUnit.CHARACTERS

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -3,41 +3,34 @@
 from steamship import File, MimeTypes, Steamship, Block
 from steamship.invocable import InvocationContext
 from steamship.plugin.inputs.raw_block_and_tag_plugin_input import RawBlockAndTagPluginInput
-from steamship.plugin.outputs.plugin_output import OperationUnit
+from steamship.plugin.outputs.plugin_output import OperationUnit, OperationType
 from steamship.plugin.request import PluginRequest
-
-
 from api import ElevenlabsPlugin
+from steamship.plugin.inputs.raw_block_and_tag_plugin_input_with_preallocated_blocks import (
+    RawBlockAndTagPluginInputWithPreallocatedBlocks,
+)
 
-def test_generator():
+def test_stream_into_block():
+    """Tests the stream"""
     with Steamship.temporary_workspace() as client:
         plugin = ElevenlabsPlugin(client, None, InvocationContext(
             invocable_instance_handle="foo"
         ))
 
         text = "Hi there"
-        req = PluginRequest(data=RawBlockAndTagPluginInput(
-            blocks=[
-                Block(text=text)
-            ]
-        ))
+        f = File.create(client)
+        output_block = Block.create(client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3)
+        usage = plugin.stream_into_block(text, output_block)
+        assert usage.operation_unit == OperationUnit.CHARACTERS
+        assert usage.operation_type == OperationType.RUN
+        assert usage.operation_amount == len(text)
+        assert usage.audit_id == f"{client.config.api_base}block/{output_block.id}/raw"
 
-        resp = plugin.run(req)
+        raw_value = output_block.raw()
+        assert raw_value is not None
 
-        assert resp.data.blocks is not None
-        block = resp.data.blocks[0]
 
-        assert block is not None
-
-        # check that Steamship thinks it is a PNG and that the bytes seem like a PNG
-        assert block.mime_type == MimeTypes.MP3
-        assert block.url is not None
-
-        assert len(resp.data.usage) == 1
-        assert resp.data.usage[0].operation_amount == len(text)
-        assert resp.data.usage[0].operation_unit == OperationUnit.CHARACTERS
-
-def test_generator_hindi():
+def test_stream_into_block_with_hindi():
     with Steamship.temporary_workspace() as client:
         plugin = ElevenlabsPlugin(client, {
             "model_id": "eleven_multilingual_v1"
@@ -46,26 +39,18 @@ def test_generator_hindi():
         ))
 
         text = "साइकिल पर एक बिल्ली"
-        req = PluginRequest(data=RawBlockAndTagPluginInput(
-            blocks=[
-                Block(text=text)
-            ]
-        ))
+        f = File.create(client)
+        output_block = Block.create(client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3)
+        usage = plugin.stream_into_block(text, output_block)
 
-        resp = plugin.run(req)
+        assert usage.operation_unit == OperationUnit.CHARACTERS
+        assert usage.operation_type == OperationType.RUN
+        assert usage.operation_amount == len(text)
+        assert usage.audit_id == f"{client.config.api_base}block/{output_block.id}/raw"
 
-        assert resp.data.blocks is not None
-        block = resp.data.blocks[0]
+        raw_value = output_block.raw()
+        assert raw_value is not None
 
-        assert block is not None
-
-        # check that Steamship thinks it is a PNG and that the bytes seem like a PNG
-        assert block.mime_type == MimeTypes.MP3
-        assert block.url is not None
-
-        assert len(resp.data.usage) == 1
-        assert resp.data.usage[0].operation_amount == len(text)
-        assert resp.data.usage[0].operation_unit == OperationUnit.CHARACTERS
 
 def test_generator_streaming():
     with Steamship.temporary_workspace() as client:
@@ -74,22 +59,33 @@ def test_generator_streaming():
         ))
 
         text = "Hi there"
-        req = PluginRequest(data=RawBlockAndTagPluginInput(
+        f = File.create(client)
+        output_block = Block.create(client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3)
+
+        req = PluginRequest(data=RawBlockAndTagPluginInputWithPreallocatedBlocks(
             blocks=[
                 Block(text=text)
+            ],
+            output_blocks=[
+                output_block
             ]
         ))
 
         resp = plugin.run(req)
 
-        assert resp.data.blocks is not None
-        block = resp.data.blocks[0]
+        assert len(resp.data.usage) == 1
+        usage = resp.data.usage[0]
 
-        assert block is not None
+        assert usage.operation_unit == OperationUnit.CHARACTERS
+        assert usage.operation_type == OperationType.RUN
+        assert usage.operation_amount == len(text)
+        assert usage.audit_id == f"{client.config.api_base}block/{output_block.id}/raw"
 
-        # check that Steamship thinks it is a PNG and that the bytes seem like a PNG
-        assert block.mime_type == MimeTypes.MP3
-        assert block.url is not None
+        raw_value = output_block.raw()
+        assert raw_value is not None
+
+        assert output_block.mime_type == MimeTypes.MP3
+        assert output_block.url is None
 
         assert len(resp.data.usage) == 1
         assert resp.data.usage[0].operation_amount == len(text)

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -1,25 +1,26 @@
 """Test dall-e generator plugin via integration tests."""
 
-from steamship import File, MimeTypes, Steamship, Block
+from steamship import Block, File, MimeTypes, Steamship
 from steamship.invocable import InvocationContext
-from steamship.plugin.inputs.raw_block_and_tag_plugin_input import RawBlockAndTagPluginInput
-from steamship.plugin.outputs.plugin_output import OperationUnit, OperationType
-from steamship.plugin.request import PluginRequest
-from api import ElevenlabsPlugin
 from steamship.plugin.inputs.raw_block_and_tag_plugin_input_with_preallocated_blocks import (
     RawBlockAndTagPluginInputWithPreallocatedBlocks,
 )
+from steamship.plugin.outputs.plugin_output import OperationType, OperationUnit
+from steamship.plugin.request import PluginRequest
+
+from api import ElevenlabsPlugin
+
 
 def test_stream_into_block():
-    """Tests the stream"""
+    """Tests streaming into a block"""
     with Steamship.temporary_workspace() as client:
-        plugin = ElevenlabsPlugin(client, None, InvocationContext(
-            invocable_instance_handle="foo"
-        ))
+        plugin = ElevenlabsPlugin(client, None, InvocationContext(invocable_instance_handle="foo"))
 
         text = "Hi there"
         f = File.create(client)
-        output_block = Block.create(client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3)
+        output_block = Block.create(
+            client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3
+        )
         usage = plugin.stream_into_block(text, output_block)
         assert usage.operation_unit == OperationUnit.CHARACTERS
         assert usage.operation_type == OperationType.RUN
@@ -31,16 +32,19 @@ def test_stream_into_block():
 
 
 def test_stream_into_block_with_hindi():
+    """Tests Hindi support."""
     with Steamship.temporary_workspace() as client:
-        plugin = ElevenlabsPlugin(client, {
-            "model_id": "eleven_multilingual_v1"
-        }, InvocationContext(
-            invocable_instance_handle="foo"
-        ))
+        plugin = ElevenlabsPlugin(
+            client,
+            {"model_id": "eleven_multilingual_v1"},
+            InvocationContext(invocable_instance_handle="foo"),
+        )
 
         text = "साइकिल पर एक बिल्ली"
         f = File.create(client)
-        output_block = Block.create(client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3)
+        output_block = Block.create(
+            client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3
+        )
         usage = plugin.stream_into_block(text, output_block)
 
         assert usage.operation_unit == OperationUnit.CHARACTERS
@@ -53,23 +57,21 @@ def test_stream_into_block_with_hindi():
 
 
 def test_generator_streaming():
+    """Tests streaming into a block with the plugin interface that wraps the raw generation method."""
     with Steamship.temporary_workspace() as client:
-        plugin = ElevenlabsPlugin(client, None, InvocationContext(
-            invocable_instance_handle="foo"
-        ))
+        plugin = ElevenlabsPlugin(client, None, InvocationContext(invocable_instance_handle="foo"))
 
         text = "Hi there"
         f = File.create(client)
-        output_block = Block.create(client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3)
+        output_block = Block.create(
+            client, file_id=f.id, streaming=True, public_data=True, mime_type=MimeTypes.MP3
+        )
 
-        req = PluginRequest(data=RawBlockAndTagPluginInputWithPreallocatedBlocks(
-            blocks=[
-                Block(text=text)
-            ],
-            output_blocks=[
-                output_block
-            ]
-        ))
+        req = PluginRequest(
+            data=RawBlockAndTagPluginInputWithPreallocatedBlocks(
+                blocks=[Block(text=text)], output_blocks=[output_block]
+            )
+        )
 
         resp = plugin.run(req)
 


### PR DESCRIPTION
This PR switches Elevenlabs over to streaming-support.

* Updates all unit tests
* Updates the integration test. (NOTE: For plugins, integration tests tend to be mostly "run it yourself demos" rather than something that would ever be automated
* Adds flake8 and git precommit hooks

